### PR TITLE
Add support for optional CSS to apply to the notification

### DIFF
--- a/notificationbox/implementation.js
+++ b/notificationbox/implementation.js
@@ -59,7 +59,10 @@ class Notification {
       }
     };
 
-    this.getNotificationBox().appendNotification(options.label, notificationId, imageURL, options.priority, buttons, callback);
+    let element = this.getNotificationBox().appendNotification(options.label, notificationId, imageURL, options.priority, buttons, callback);
+    for (let key in options.style) {
+      element.style[key] = options.style[key];
+    }
   }
 
   getNotificationBox() {

--- a/notificationbox/schema.json
+++ b/notificationbox/schema.json
@@ -70,6 +70,14 @@
             "description": "The placement of the notification.",
             "type": "string",
             "enum": ["default", "top", "bottom"]
+          },
+          "style": {
+            "optional": true,
+            "description": "Additional CSS to apply to the notification.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },


### PR DESCRIPTION
This lets extensions customise the appearance of the notification somewhat (e.g. foreground and background colours).