### PR TITLE
Allow extensions to choose the placement of the notification

### DIFF
--- a/notificationbox/implementation.js
+++ b/notificationbox/implementation.js
@@ -1,7 +1,8 @@
 "use strict";
 
-const { EventEmitter, EventManager, ExtensionAPI } = ExtensionCommon;
-const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var { EventEmitter, EventManager, ExtensionAPI } = ExtensionCommon;
+var { ExtensionError } = ExtensionUtils;
+var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 XPCOMUtils.defineLazyServiceGetters(this, {
   UUIDGen: ["@mozilla.org/uuid-generator;1", "nsIUUIDGenerator"],
@@ -18,7 +19,8 @@ class Notification {
     this.notificationId = notificationId;
     this.options = options;
     this.parent = parent;
-    this.imageURL = options.iconUrl
+
+    let imageURL = options.image
       ? parent.extension.baseURI.resolve(options.image)
       : null;
    
@@ -57,7 +59,7 @@ class Notification {
       }
     };
 
-    this.getNotificationBox().appendNotification(this.options.label, this.notificationId, this.imageURL, this.options.priority, buttons, callback);
+    this.getNotificationBox().appendNotification(options.label, notificationId, imageURL, options.priority, buttons, callback);
   }
 
   getNotificationBox() {
@@ -72,7 +74,7 @@ class Notification {
       return w.gNotification.notificationbox;
     }
     else {
-      throw new Error("Can't find a notification bar");
+      throw new ExtensionError("Can't find a notification bar");
     }
   }
   

--- a/notificationbox/implementation.js
+++ b/notificationbox/implementation.js
@@ -64,18 +64,33 @@ class Notification {
 
   getNotificationBox() {
     let w = this.parent.extension.windowManager.get(this.windowId, this.parent.context).window;
-    if (w.gMessageNotificationBar) {
-      return w.gMessageNotificationBar.msgNotificationBar;
+    switch (this.options.placement) {
+    default:
+      if (w.gMessageNotificationBar) {
+        return w.gMessageNotificationBar.msgNotificationBar;
+      }
+    case "bottom":
+      if (w.specialTabs) {
+        return wspecialTabs.msgNotificationBar;
+      }
+      if (w.gNotification) {
+        return w.gNotification.notificationbox;
+      }
+    case "top":
+      if (w.gExtensionNotificationBox) {
+        return w.gExtensionNotificationBox;
+      }
+      let toolbox = w.document.querySelector("toolbox");
+      if (toolbox) {
+        w.gExtensionNotificationBox = new w.MozElements.NotificationBox(element => {
+          element.id = "extension-notification-box";
+          element.setAttribute("notificationside", "top");
+          toolbox.parentElement.insertBefore(element, toolbox.nextElementSibling);
+        });
+        return w.gExtensionNotificationBox;
+      }
     }
-    else if (w.specialTabs) {
-      return wspecialTabs.msgNotificationBar;
-    }
-    else if (w.gNotification) {
-      return w.gNotification.notificationbox;
-    }
-    else {
-      throw new ExtensionError("Can't find a notification bar");
-    }
+    throw new ExtensionError("Can't find a notification bar");
   }
   
   remove(closedByUser) {

--- a/notificationbox/schema.json
+++ b/notificationbox/schema.json
@@ -34,6 +34,13 @@
             "description": "Text and icons for up to two notification action buttons.",
             "type": "array",
             "items": { "$ref": "Button" }
+          },
+          "placement": {
+            "optional": true,
+            "default": "default",
+            "description": "The placement of the notification.",
+            "type": "string",
+            "enum": ["default", "top", "bottom"]
           }
         }
       },

--- a/notificationbox/schema.json
+++ b/notificationbox/schema.json
@@ -30,6 +30,7 @@
           },
           "buttons": {
             "optional": true,
+            "default": [],
             "description": "Text and icons for up to two notification action buttons.",
             "type": "array",
             "items": { "$ref": "Button" }
@@ -43,7 +44,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "desciption": "The id of the button. Is send in onButtonClicked events."
+            "desciption": "The id of the button. Is sent in onButtonClicked events."
           },
           "label": {
             "type": "string",


### PR DESCRIPTION
Above the message pane isn't the most obvious place to put a notification, but I left it as the default setting. The case statements fall through which emulates the previous behaviour of trying all known locations.