### PR TITLE
Allow clearing notifications again

### DIFF
--- a/notificationbar/schema.json
+++ b/notificationbar/schema.json
@@ -127,7 +127,7 @@
         "async": true,
         "parameters": [
           {
-            "type": "string",
+            "type": "integer",
             "name": "notificationId",
             "description": "The ID of the notification to be removed."
           }
@@ -154,7 +154,7 @@
             "description": "The ID of the window containing the notification of the clicked button."
           },
           {
-            "type": "string",
+            "type": "integer",
             "name": "notificationId",
             "description": "The ID of the notification of the clicked button."
           },
@@ -176,7 +176,7 @@
             "description": "The ID of the window containing the dismissed notification."
           },
           {
-            "type": "string",
+            "type": "integer",
             "name": "notificationId",
             "description": "The ID of the dismissed notification."
           }
@@ -193,7 +193,7 @@
             "description": "The ID of the window containing the closed notification."
           },
           {
-            "type": "string",
+            "type": "integer",
             "name": "notificationId",
             "description": "The ID of the closed notification."
           },
@@ -203,7 +203,7 @@
             "description": "The notification was closed by the user."
           }
         ]
-      }      
+      }
     ]
   }
 ]


### PR DESCRIPTION
Notification ids are now integers so the `clear` API needs to be updated.