### PR TITLE
Fix bottom-positioned notificationbar in a compose window.

### DIFF
--- a/notificationbar/implementation.js
+++ b/notificationbar/implementation.js
@@ -129,7 +129,7 @@ class Notification {
               element.id = "extension-notification-bottom-box";
               element.setAttribute("notificationside", "bottom");
               if (statusbar) {
-                w.document.documentElement.insertBefore(element, statusbar);
+                statusbar.parentNode.insertBefore(element, statusbar);
               } else {
                 w.document.documentElement.append(element);
               }


### PR DESCRIPTION
Use statusbar.parentNode instead of document.documentElement when statusbar is set.

This fixes an issue in Thunderbird 90beta with bottom positioned notficationbars not appearing.

The statusbar element is now a child of <html:body>. This change is based on the MDN [example](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore#example_1) which gets the parent of the reference node (statusbar) with it's parentNode property.