### PR TITLE
Fix for status bar changing to an html element.

### DIFF
--- a/notificationbar/implementation.js
+++ b/notificationbar/implementation.js
@@ -123,7 +123,7 @@ class Notification {
         }
         // if there is no default bottom box, use our own
         if (!w.gExtensionNotificationBottomBox) {
-          let statusbar = w.document.querySelector('hbox[class~="statusbar"]');
+          let statusbar = w.document.querySelector('[class~="statusbar"]');
           w.gExtensionNotificationBottomBox = new w.MozElements.NotificationBox(
             element => {
               element.id = "extension-notification-bottom-box";


### PR DESCRIPTION
The compose window status bar element was changed to an <html:div> in bug 1683865
(milestone 93). A quick search shows that other windows (esp. messenger.xhtml)
have not made the change yet.

Using just the class "statubar" to locate it should be sufficient and should work
in the cases where the statusbar is still an <hbox> as well as cases where it's
been changed.