### PR TITLE
Fix for "onDismissed" event.

### DIFF
--- a/notificationbar/implementation.js
+++ b/notificationbar/implementation.js
@@ -77,9 +77,9 @@ class Notification {
           label,
           image: iconURL,
           priority,
+          eventCallback: notificationBarCallback,
         },
         buttonSet,
-        notificationBarCallback
       );
     }
     let allowedCssPropNames = [


### PR DESCRIPTION
Bug 1690390 also moved aEventCallback into aNotification. This broke the onDismissed event handling.

This fix is included in MarkdownHere Revival 3.4.4, coming soon to ATN.