### PR TITLE
Use Services global variable if possible

### DIFF
--- a/notificationbar/implementation.js
+++ b/notificationbar/implementation.js
@@ -4,7 +4,9 @@
 
 var { EventEmitter, EventManager, ExtensionAPI } = ExtensionCommon;
 var { ExtensionError } = ExtensionUtils;
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 class Notification {
   constructor(notificationId, properties, parent) {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.

forwarded from https://gitlab.com/jfx2006/markdown-here-revival/-/merge_requests/3